### PR TITLE
Fix build issue due to renaming README file

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
README was renamed to README.md after moving source to Github
but autotools expect README to be present during the build.