### PR TITLE
Allow to override build date

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -339,7 +339,8 @@ else
 	AC_MSG_RESULT(no)
 fi
 
-timestamp=`date`
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-`date +%s`}"
+timestamp=`date -u -d "@$SOURCE_DATE_EPOCH" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" 2>/dev/null || date -u`
 
 AC_DEFINE_UNQUOTED([CONFIGURED_ON],["$timestamp"],[Configured on])
 AC_DEFINE_UNQUOTED([BUILD_DATE],["$timestamp"],[Built on])


### PR DESCRIPTION
and use UTC (to be inpendent of timezones)
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.
This date call works with GNU and BSD date variants.