### PR TITLE
Add new -P and -R options for master port and stats

### DIFF
--- a/docs/manual.html
+++ b/docs/manual.html
@@ -59,7 +59,7 @@
         describing the test application. 
         </p><pre class="programlisting">
 Uperf Version 1.0.6
-Usage:   uperf [-m profile] [-hvV] [-ngtTfkpaeE:X:i:]
+Usage:   uperf [-m profile] [-hvV] [-ngtTfkpaeE:X:i:P:]
          uperf [-s] [-hvV]
 
         -m &lt;profile&gt;     Run uperf with this profile
@@ -74,11 +74,12 @@ Usage:   uperf [-m profile] [-hvV] [-ngtTfkpaeE:X:i:]
         -e               Collect default CPU counters for flowops [-f assumed]
         -E &lt;ev1,ev2&gt;     Collect CPU counters for flowops [-f assumed]
         -a               Collect all statistics
-        -X file          collect response times
+        -X &lt;file&gt;        Collect response times
+        -i &lt;interval&gt;    Collect throughput every &lt;interval&gt;
+        -P &lt;port&gt;        Set the master port (defaults to 20000)
         -v               Verbose
         -V               Version
         -h               Print usage
-        -i &lt;interval&gt;    collect throughput every &lt;interval&gt;
 
 More information at http://www.uperf.org
         </pre><p>

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -59,7 +59,7 @@
         describing the test application. 
         </p><pre class="programlisting">
 Uperf Version 1.0.6
-Usage:   uperf [-m profile] [-hvV] [-ngtTfkpaeE:X:i:P:]
+Usage:   uperf [-m profile] [-hvV] [-ngtTfkpaeE:X:i:P:R]
          uperf [-s] [-hvV]
 
         -m &lt;profile&gt;     Run uperf with this profile
@@ -77,6 +77,7 @@ Usage:   uperf [-m profile] [-hvV] [-ngtTfkpaeE:X:i:P:]
         -X &lt;file&gt;        Collect response times
         -i &lt;interval&gt;    Collect throughput every &lt;interval&gt;
         -P &lt;port&gt;        Set the master port (defaults to 20000)
+        -R               Emit raw (not transformed), time-stamped (ms) statistics
         -v               Verbose
         -V               Version
         -h               Print usage

--- a/manual/uperf-help.txt
+++ b/manual/uperf-help.txt
@@ -1,6 +1,6 @@
 Uperf Version 1.0.6
-Usage:   src/uperf [-m profile] [-hvV] [-ngtTfkpaeE:X:i:]
-         src/uperf [-s] [-hvV]
+Usage:   uperf [-m profile] [-hvV] [-ngtTfkpaeE:X:i:P:]
+         uperf [-s] [-hvV]
 
         -m <profile>     Run uperf with this profile
         -s               Slave
@@ -14,10 +14,11 @@ Usage:   src/uperf [-m profile] [-hvV] [-ngtTfkpaeE:X:i:]
         -e               Collect default CPU counters for flowops [-f assumed]
         -E <ev1,ev2>     Collect CPU counters for flowops [-f assumed]
         -a               Collect all statistics
-        -X file          collect response times
+        -X <file>        Collect response times
+        -i <interval>    Collect throughput every <interval>
+        -P <port>        Set the master port (defaults to 20000)
         -v               Verbose
         -V               Version
         -h               Print usage
-        -i <interval>    collect throughput every <interval>
 
 More information at http://www.uperf.org

--- a/manual/uperf-help.txt
+++ b/manual/uperf-help.txt
@@ -1,5 +1,5 @@
 Uperf Version 1.0.6
-Usage:   uperf [-m profile] [-hvV] [-ngtTfkpaeE:X:i:P:]
+Usage:   uperf [-m profile] [-hvV] [-ngtTfkpaeE:X:i:P:R]
          uperf [-s] [-hvV]
 
         -m <profile>     Run uperf with this profile
@@ -17,6 +17,7 @@ Usage:   uperf [-m profile] [-hvV] [-ngtTfkpaeE:X:i:P:]
         -X <file>        Collect response times
         -i <interval>    Collect throughput every <interval>
         -P <port>        Set the master port (defaults to 20000)
+        -R               Emit raw (not transformed), time-stamped (ms) statistics
         -v               Verbose
         -V               Version
         -h               Print usage

--- a/src/main.c
+++ b/src/main.c
@@ -70,7 +70,7 @@ static void
 uperf_usage(char *prog)
 {
 	(void) printf("Uperf Version %s\n", UPERF_VERSION);
-	(void) printf("Usage:   %s [-m profile] [-hvV] [-ngtTfkpaeE:X:i:]\n",
+	(void) printf("Usage:   %s [-m profile] [-hvV] [-ngtTfkpaeE:X:i:P:]\n",
 	    prog);
 	(void) printf("\t %s [-s] [-hvV]\n\n", prog);
 	(void) printf(
@@ -86,11 +86,12 @@ uperf_usage(char *prog)
 	"\t-e\t\t Collect default CPU counters for flowops [-f assumed]\n"
 	"\t-E <ev1,ev2>\t Collect CPU counters for flowops [-f assumed]\n"
 	"\t-a\t\t Collect all statistics\n"
-	"\t-X file\t\t collect response times\n"
+	"\t-X <file>\t Collect response times\n"
+	"\t-i <interval>\t Collect throughput every <interval>\n"
+	"\t-P <port>\t Set the master port (defaults to 20000)\n"
 	"\t-v\t\t Verbose\n"
 	"\t-V\t\t Version\n"
 	"\t-h\t\t Print usage\n"
-	"\t-i <interval>\t collect throughput every <interval>\n"
 	"\nMore information at http://www.uperf.org\n");
 }
 
@@ -153,9 +154,10 @@ init_options(int argc, char **argv)
 	options.copt |= PACKET_STATS;
 
 	options.interval = 1000;	/* Collect throughput every 1second */
+	options.master_port = MASTER_PORT;
 	oserver = oclient = ofile = 0;
 
-	while ((ch = getopt(argc, argv, "i:hngm:stTfkpaeE:vVX:")) != EOF) {
+	while ((ch = getopt(argc, argv, "E:epTgtfknasm:X:i:P:vVh")) != EOF) {
 		switch (ch) {
 #ifdef USE_CPC
 		case 'E':
@@ -237,13 +239,6 @@ init_options(int argc, char **argv)
 			ofile++;
 			break;
 #endif
-		case 'v':
-			uperf_set_log_level(UPERF_VERBOSE);
-			break;
-		case 'V':
-			uperf_version();
-			exit(0);
-			break;
 		case 'X':
 			options.copt |= HISTORY_STATS;
 			if (optarg) {
@@ -267,7 +262,19 @@ init_options(int argc, char **argv)
 				uperf_fatal("Please specify interval\n");
 			}
 			break;
-
+		case 'P':
+			if (optarg) {
+				options.master_port = (int)
+					string_to_int(optarg);
+			}
+			break;
+		case 'v':
+			uperf_set_log_level(UPERF_VERBOSE);
+			break;
+		case 'V':
+			uperf_version();
+			exit(0);
+			break;
 		case 'h':
 			uperf_usage(argv[0]);
 			exit(0);

--- a/src/main.c
+++ b/src/main.c
@@ -70,7 +70,7 @@ static void
 uperf_usage(char *prog)
 {
 	(void) printf("Uperf Version %s\n", UPERF_VERSION);
-	(void) printf("Usage:   %s [-m profile] [-hvV] [-ngtTfkpaeE:X:i:P:]\n",
+	(void) printf("Usage:   %s [-m profile] [-hvV] [-ngtTfkpaeE:X:i:P:R]\n",
 	    prog);
 	(void) printf("\t %s [-s] [-hvV]\n\n", prog);
 	(void) printf(
@@ -89,6 +89,7 @@ uperf_usage(char *prog)
 	"\t-X <file>\t Collect response times\n"
 	"\t-i <interval>\t Collect throughput every <interval>\n"
 	"\t-P <port>\t Set the master port (defaults to 20000)\n"
+	"\t-R\t\t Emit raw (not transformed), time-stamped (ms) statistics\n"
 	"\t-v\t\t Verbose\n"
 	"\t-V\t\t Version\n"
 	"\t-h\t\t Print usage\n"
@@ -157,7 +158,7 @@ init_options(int argc, char **argv)
 	options.master_port = MASTER_PORT;
 	oserver = oclient = ofile = 0;
 
-	while ((ch = getopt(argc, argv, "E:epTgtfknasm:X:i:P:vVh")) != EOF) {
+	while ((ch = getopt(argc, argv, "E:epTgtfknasm:X:i:P:RvVh")) != EOF) {
 		switch (ch) {
 #ifdef USE_CPC
 		case 'E':
@@ -267,6 +268,9 @@ init_options(int argc, char **argv)
 				options.master_port = (int)
 					string_to_int(optarg);
 			}
+			break;
+		case 'R':
+			options.copt |= RAW_STATS;
 			break;
 		case 'v':
 			uperf_set_log_level(UPERF_VERBOSE);

--- a/src/main.h
+++ b/src/main.h
@@ -56,6 +56,7 @@
 
 /* options structure - has basic program options */
 typedef struct options {
+	int	master_port;
 	int	run_choice;	/* master or slave */
 	char	app_profile_name[PATH_MAX];
 	int	bitorbyte;

--- a/src/main.h
+++ b/src/main.h
@@ -35,6 +35,7 @@
 #define	GROUP_STATS		(1<<9)
 #define	UTILIZATION_STATS	(1<<11)
 #define	NO_STATS		(1<<12)
+#define RAW_STATS		(1<<13)
 
 #define	ENABLED_FLOWOP_STATS(a)		((a).copt & FLOWOP_STATS)
 #define	ENABLED_TXN_STATS(a)		((a).copt & TXN_STATS)
@@ -47,12 +48,13 @@
 #define	ENABLED_UTILIZATION_STATS(a)	((a).copt & UTILIZATION_STATS)
 #define	DISABLED_STATS(a)		((a).copt & NO_STATS)
 #define	ENABLED_STATS(a)		(!DISABLED_STATS(a))
+#define ENABLED_RAW_STATS(a)		((a).copt & RAW_STATS)
 
 #define	UPERF_MASTER		(1<<0)
-#define	UPERF_SLAVE			(1<<1)
+#define	UPERF_SLAVE		(1<<1)
 
 #define	IS_MASTER(a)		((a).run_choice & UPERF_MASTER)
-#define	IS_SLAVE(a)			((a).run_choice & UPERF_SLAVE)
+#define	IS_SLAVE(a)		((a).run_choice & UPERF_SLAVE)
 
 /* options structure - has basic program options */
 typedef struct options {

--- a/src/master.c
+++ b/src/master.c
@@ -359,7 +359,7 @@ new_control_connection(group_t *g, char *host)
 		p = p->next;
 	}
 	/* Not found, create a new one */
-	p = create_protocol(PROTOCOL_TCP, host, MASTER_PORT, MASTER);
+	p = create_protocol(PROTOCOL_TCP, host, options.master_port, MASTER);
 	if (p != NULL) {
 		/* Try connecting */
 		if (p->connect(p, NULL) == 0) {

--- a/src/print.c
+++ b/src/print.c
@@ -105,21 +105,27 @@ print_summary(newstats_t *ns, int same_line)
 	if (time <= 0) {
 		return;
 	}
-	time_s = time/1.0e+9;
-	throughput = ns->size * 8.0 / time_s;
-	ops = ns->count/time_s;
-	if (same_line) {
-		memset(msg, ' ', sizeof (msg));
-		msg[window_width() - 1] = '\0';
-		printf("\r%s\r", msg);
+
+	if (ENABLED_RAW_STATS(options)) {
+		printf("timestamp_ms:%.4f name:%s nr_bytes:%lu nr_ops:%lu\n",
+			ns->end_time/1.0e+6, ns->name, ns->size, ns->count);
+	} else {
+		time_s = time/1.0e+9;
+		throughput = ns->size * 8.0 / time_s;
+		ops = ns->count/time_s;
+		if (same_line) {
+			memset(msg, ' ', sizeof (msg));
+			msg[window_width() - 1] = '\0';
+			printf("\r%s\r", msg);
+		}
+		printf("%-8.8s ", ns->name);
+		PRINT_NUM(ns->size, 8);
+		printf("/%7.2f(s) = ", time/1.0e+9);
+		PRINT_NUMb(throughput, 12);
+		printf(" %10.0fop/s ", ops);
+		if (same_line == 0)
+			(void) printf("\n");
 	}
-	printf("%-8.8s ", ns->name);
-	PRINT_NUM(ns->size, 8);
-	printf("/%7.2f(s) = ", time/1.0e+9);
-	PRINT_NUMb(throughput, 12);
-	printf(" %10.0fop/s ", ops);
-	if (same_line == 0)
-		(void) printf("\n");
 	(void) fflush(stdout);
 }
 

--- a/src/slave.c
+++ b/src/slave.c
@@ -423,7 +423,7 @@ slave()
 	if (setup_slave_signal() != 0) {
 		return (1);
 	}
-	slave_conn = create_protocol(PROTOCOL_TCP, "", MASTER_PORT, SLAVE);
+	slave_conn = create_protocol(PROTOCOL_TCP, "", options.master_port, SLAVE);
 	if (slave_conn == NULL) {
 		uperf_error("Cannot create control connection\n");
 		return (1);


### PR DESCRIPTION
This PR depends on #21 landing first, since that fixes up the build environment, and addresses the uperf version information.  The two commits from #21 will be a part of this commit until #21 merges and we rebase. 

The first patch provides the `-P` option for specifying the master port to use.  The second patch provides the `-R` option for emitting raw statistics.