### PR TITLE
Fix Warnings on Ubuntu 18.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ config.status
 .deps
 src/uperf
 src/*.o
+tests/*.log
+tests/*.trs

--- a/src/master.c
+++ b/src/master.c
@@ -77,7 +77,7 @@ static int
 say_goodbye(goodbye_stat_t *total, protocol_t *p, int timeout)
 {
 	goodbye_t g;
-	char msg[GOODBYE_MESSAGE_LEN];
+	char msg[GOODBYE_MESSAGE_LEN + MAXHOSTNAME + 4];
 
 	if (recv_goodbye(&g, p, timeout) != UPERF_SUCCESS) {
 		uperf_error("\nError saying goodbye with %s\n", p->host);
@@ -86,19 +86,19 @@ say_goodbye(goodbye_stat_t *total, protocol_t *p, int timeout)
 
 	switch (g.msg_type) {
 		case MESSAGE_INFO:
-			(void) snprintf(msg, GOODBYE_MESSAGE_LEN,
+			(void) snprintf(msg, sizeof(msg),
 			    "[%s] %s", p->host, g.message);
 			uperf_info(msg);
 			break;
 		case MESSAGE_NONE:
 			break;
 		case MESSAGE_ERROR:
-			(void) snprintf(msg, GOODBYE_MESSAGE_LEN,
+			(void) snprintf(msg, sizeof(msg),
 			    "[%s] %s", p->host, g.message);
 			uperf_log_msg(UPERF_LOG_ERROR, 0, msg);
 			break;
 		case MESSAGE_WARNING:
-			(void) snprintf(msg, GOODBYE_MESSAGE_LEN,
+			(void) snprintf(msg, sizeof(msg),
 			    "[%s] %s\n", p->host, g.message);
 			uperf_log_msg(UPERF_LOG_WARN, 0, msg);
 			break;
@@ -206,7 +206,7 @@ send_command_to_slaves(uperf_cmd cmd, int value)
 	for (i = 0; i < no_slaves; i++) {
 		ret = uperf_send_command(slaves[i], cmd, value);
 		if (ret <= 0) {
-			char msg[128];
+			char msg[MAXHOSTNAME + 64];
 			(void) snprintf(msg, sizeof (msg),
 			    "Could not send command %d to %s:%d ",
 			    value, slaves[i]->host, slaves[i]->port);

--- a/src/numbers.c
+++ b/src/numbers.c
@@ -209,7 +209,7 @@ adaptive_print_time(double value, int width)
 	int acutal_width;
 	int index = 0;
 	static char prefix[] = "num";
-	char format[16];
+	char format[32];
 
 	if (width > 127) {
 		width = 127;

--- a/src/uperf.h
+++ b/src/uperf.h
@@ -19,9 +19,9 @@
 #define		_UPERF_H
 
 /* Keep the data version as 0.2.5 to avoid the version mismatch problem. */
-#define UPERF_DATA_VERSION	"0.3"
+#define UPERF_DATA_VERSION	"0.3.1"
 #define	UPERF_VERSION 		"1.0.7"
-#define	UPERF_VERSION_LEN 	128
+#define	UPERF_VERSION_LEN 	16
 #define	UPERF_EMAIL_ALIAS	"uperf-discuss@lists.sourceforge.net"
 
 #define	MAXHOSTNAME		256


### PR DESCRIPTION
Fix incorrectly size buffers. Bump up the data version as we are
changing the handshake structure size. Fixes #35