### PR TITLE
Add mutex lock around shared variable access

### DIFF
--- a/src/sync.c
+++ b/src/sync.c
@@ -83,7 +83,18 @@ unlock_barrier(barrier_t *bar)
 int
 barrier_notreached(barrier_t *bar)
 {
-	return (bar->limit - bar->count);
+	int remaining;
+	if (pthread_mutex_lock(&bar->count_mutex) != 0) {
+		printf("Error grabbing count mutex.. aborting\n");
+		exit(1);
+	}
+	remaining = bar->limit - bar->count;
+
+	if (pthread_mutex_unlock(&bar->count_mutex) != 0) {
+		printf("Error releasing count mutex.. aborting\n");
+		exit(1);
+	}
+	return remaining;
 }
 int
 wait_barrier(barrier_t *bar)

--- a/src/sync.c
+++ b/src/sync.c
@@ -83,19 +83,7 @@ unlock_barrier(barrier_t *bar)
 int
 barrier_notreached(barrier_t *bar)
 {
-    int remaining;
-	if (pthread_mutex_lock(&bar->count_mutex) != 0) {
-		printf("Error grabbing count mutex.. aborting\n");
-		exit(1);
-	}
-    remaining = bar->limit - bar->count;
-
-	if (pthread_mutex_unlock(&bar->count_mutex) != 0) {
-		printf("Error releasing count mutex.. aborting\n");
-		exit(1);
-	}
-
-	return remaining;
+	return (bar->limit - bar->count);
 }
 int
 wait_barrier(barrier_t *bar)

--- a/src/sync.c
+++ b/src/sync.c
@@ -83,7 +83,19 @@ unlock_barrier(barrier_t *bar)
 int
 barrier_notreached(barrier_t *bar)
 {
-	return (bar->limit - bar->count);
+    int remaining;
+	if (pthread_mutex_lock(&bar->count_mutex) != 0) {
+		printf("Error grabbing count mutex.. aborting\n");
+		exit(1);
+	}
+    remaining = bar->limit - bar->count;
+
+	if (pthread_mutex_unlock(&bar->count_mutex) != 0) {
+		printf("Error releasing count mutex.. aborting\n");
+		exit(1);
+	}
+
+	return remaining;
 }
 int
 wait_barrier(barrier_t *bar)


### PR DESCRIPTION
This was an issue brought up by the [llvm thread sanitizer ](https://clang.llvm.org/docs/ThreadSanitizer.html), not a bug I was able to track down in the wild. I am not sure this is the *right* thing to do as this codebase also uses atomics in places instead of mutex locks. But when I was tracing the function calls I didn't see any locking. There is a comment to, "unlock this barrier" [here](https://github.com/uperf/uperf/blob/master/src/slave.c#L174). If I have made an error or overlooked something, please let me know as I am interested in learning about this code base. 