### PR TITLE
Add testing for large numbers of threads and processes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ config.status
 .deps
 src/uperf
 src/*.o
+src/*.gcda
+src/*.gcno
 tests/*.log
 tests/*.trs

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,7 +6,7 @@ TESTS = unknown_proto.xml parse_err.xml 01simple_tcp.xml 02two_groups.xml \
 	high_connection_count.xml test_4groups.xml \
 	test_netperf.xml test-sendfilev-chunked.xml \
 	test-sendfile.xml test_send_recv.xml test-rate.xml \
-	test-sendfilev.xml 
+	test-sendfilev.xml max_thread_count.xml max_procs_count.xml
 
 XFAIL_TESTS = unknown_proto.xml parse_err.xml
 
@@ -17,7 +17,7 @@ endif
 
 if SCTP_C
 TESTS += 01simple_sctp.xml 3proto.xml accept-sctp.xml multi_proto_connect.xml \
-	throughput_sctp.xml 02_2proto1group.xml a.xml 
+	throughput_sctp.xml 02_2proto1group.xml a.xml
 endif
 
 if SSL_C

--- a/tests/max_procs_count.xml
+++ b/tests/max_procs_count.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<profile name="max_procs_count.xml">
+  <group nprocs="1024">
+        <transaction iterations="1">
+            <flowop type="connect" options="remotehost=$h protocol=tcp"/>
+        </transaction>
+        <transaction duration="10s">
+            <flowop type="write" options="size=64"/>
+            <flowop type="read" options="size=1024"/>
+        </transaction>
+        <transaction >
+            <flowop type="disconnect" />
+        </transaction>
+  </group>
+
+</profile>

--- a/tests/max_thread_count.xml
+++ b/tests/max_thread_count.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<profile name="max_thread_count.xml">
+  <group nthreads="1024">
+        <transaction iterations="1">
+            <flowop type="connect" options="remotehost=$h protocol=tcp tcp_nodelay"/>
+        </transaction>
+        <transaction iterations="50">
+            <flowop type="write" options="size=256"/>
+            <flowop type="read" options="size=64"/>
+        </transaction>
+        <transaction >
+            <flowop type="disconnect" />
+        </transaction>
+  </group>
+
+</profile>


### PR DESCRIPTION
I have done testing with a large 256,512 threads or processes and occasionally have seen a "connection reset by peer" message on the client side. I have been trying to get to debug them, but haven't been successful yet. I am hoping that by adding these tests others can try out the problem and hopefully we can find the problem and solution. 
To be clear, the tests in this PR pass on my localhost and LAN. 