### PR TITLE
github actions CI

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,27 @@
+name: make check CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install sctp
+      run: sudo apt-get install -y libsctp-dev
+    - name: insmod sctp
+      run: sudo modprobe sctp
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+    - name: start localhost server
+      run: ./src/uperf -s &
+    - name: make check
+      run: make check


### PR DESCRIPTION
Issue #27 brings up the topic of CI. Github offers CI on Linux (ubuntu) and Windows but unfortunately not FreeBSD, MacOS, or Solaris. 
This PR will do a `make check` in an ubuntu-latest environment on pushes and pull requests to the master branch. 
If this is merged, I caution that there is email generated related to the actions failures or successes, so notification settings might need to be adjusted