### PR TITLE
update atomic.h to stdatomic.h, update function calls

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -219,7 +219,7 @@ else
 	AC_MSG_RESULT(no)
 fi
 
-AC_CHECK_HEADERS([atomic.h siginfo.h sys/int_limits.h sys/lwp.h signal.h sys/byteorder.h poll.h sys/poll.h sys/varargs.h stdint.h termio.h stropts.h sys/ttycom.h wait.h alloca.h sys/sendfile.h sys/types.h linux/unistd.h sys/ioctl.h sys/uio.h])
+AC_CHECK_HEADERS([stdatomic.h atomic.h siginfo.h sys/int_limits.h sys/lwp.h signal.h sys/byteorder.h poll.h sys/poll.h sys/varargs.h stdint.h termio.h stropts.h sys/ttycom.h wait.h alloca.h sys/sendfile.h sys/types.h linux/unistd.h sys/ioctl.h sys/uio.h])
 
 LIBS="$UPERF_LIBS"
 AC_CHECK_FUNCS([nanosleep])

--- a/src/execute.c
+++ b/src/execute.c
@@ -19,9 +19,6 @@
 #ifdef HAVE_CONFIG_H
 #include "../config.h"
 #endif /* HAVE_CONFIG_H */
-#ifdef HAVE_ATOMIC_H
-#include <atomic.h>
-#endif /* HAVE_ATOMIC_H */
 #include <assert.h>
 #ifdef HAVE_SIGNAL_H
 #include <signal.h> /* For SIGUSR2 */

--- a/src/shm.c
+++ b/src/shm.c
@@ -29,6 +29,9 @@
 #ifdef HAVE_ATOMIC_H
 #include <atomic.h>
 #endif /* HAVE_ATOMIC_H */
+#ifdef HAVE_STDATOMIC_H
+#include <stdatomic.h>
+#endif /* HAVE_STDATOMIC_H */
 #include <sys/types.h>
 
 #ifdef HAVE_STRING_H
@@ -286,11 +289,13 @@ shm_fini(uperf_shm_t *shm)
 void
 shm_update_strand_exit(uperf_shm_t *shm)
 {
-#ifdef HAVE_ATOMIC_H
+#ifdef HAVE_STDATOMIC_H
+	(void) atomic_fetch_add(&shm->finished, 1);
+#elif defined(HAVE_ATOMIC_H)
 	atomic_add_32(&shm->finished, 1);
 #else
 	shm->finished++;
-#endif /* HAVE_ATOMIC_H */
+#endif /* HAVE_ATOMIC_H or HAVE_STDATOMIC_H */
 }
 
 void

--- a/src/sync.h
+++ b/src/sync.h
@@ -32,10 +32,10 @@
 typedef	struct sync_barrier {
 	pthread_rwlockattr_t rwattr;
 	pthread_rwlock_t barrier;
-#ifndef HAVE_ATOMIC_H
+#if !defined(HAVE_ATOMIC_H) && !defined(HAVE_STDATOMIC_H)
 	pthread_mutexattr_t count_mtx_attr;
 	pthread_mutex_t count_mutex;
-#endif /* HAVE_ATOMIC_H */
+#endif /* HAVE_ATOMIC_H  && HAVE_STDATOMIC_H */
 	volatile unsigned int count;
 	volatile unsigned int limit;
 	int group;


### PR DESCRIPTION
I was compiling on fedora 34 and noticed that `./configure` output `no` for atomics. I dug into it a bit and realized that the configure.ac was checking for `atomic.h` when it is `stdatomic.h`, at least on linux. I know that uperf compiles and runs on FreeBSD and I don't have a vm handy to check that at the moment, so if this needs to be changed for that env I am happy to do that.