### PR TITLE
configure: Fix sendfilev test for better C99 compatibility

### DIFF
--- a/configure
+++ b/configure
@@ -4389,7 +4389,7 @@ $as_echo_n "checking sendfilev... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <sys/sendfile.h>
-		main() {int i=sendfilev(1,0, 1, 0);}
+		int main() {int i=sendfilev(1,0, 1, 0);}
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -100,7 +100,7 @@ AC_LINK_IFELSE([AC_LANG_SOURCE[#include <sys/byteorder.h>
 # Linux 2.6 does not have sendfilev
 AC_MSG_CHECKING(sendfilev)
 AC_LINK_IFELSE([AC_LANG_SOURCE[#include <sys/sendfile.h>
-		main() {int i=sendfilev(1,0, 1, 0);}]],
+		int main() {int i=sendfilev(1,0, 1, 0);}]],
 		[AC_MSG_RESULT(yes)
 	  	 AC_DEFINE([HAVE_SENDFILEV],[1],[Have sendfilev])
 		],


### PR DESCRIPTION
Implicit int as a language feature was removed in 1999, so this check can incorrectly fail with C99 compilers even if the sendfilev function is actually present.