### PR TITLE
Fix sendfilev test for better C99 compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,7 +100,7 @@ AC_LINK_IFELSE([AC_LANG_SOURCE[#include <sys/byteorder.h>
 # Linux 2.6 does not have sendfilev
 AC_MSG_CHECKING(sendfilev)
 AC_LINK_IFELSE([AC_LANG_SOURCE[#include <sys/sendfile.h>
-		main() {int i=sendfilev(1,0, 1, 0);}]],
+		int main() {int i=sendfilev(1,0, 1, 0);}]],
 		[AC_MSG_RESULT(yes)
 	  	 AC_DEFINE([HAVE_SENDFILEV],[1],[Have sendfilev])
 		],


### PR DESCRIPTION
Implicit int as a language feature was removed in 1999, so this check can incorrectly fail with C99 compilers even if the sendfilev function is actually present.