### PR TITLE
call group_free in server code

### DIFF
--- a/src/slave.c
+++ b/src/slave.c
@@ -359,6 +359,7 @@ slave_master(protocol_t *p)
 	uperf_log_flush();
 	/* fprintf(stderr, "%ld: master-slave exiting\n", getpid()); */
 	p->disconnect(p);
+    group_free(shm->worklist);
 	free(shm);
 
 	return (0);

--- a/src/slave.c
+++ b/src/slave.c
@@ -359,7 +359,7 @@ slave_master(protocol_t *p)
 	uperf_log_flush();
 	/* fprintf(stderr, "%ld: master-slave exiting\n", getpid()); */
 	p->disconnect(p);
-    group_free(shm->worklist);
+	group_free(shm->worklist);
 	free(shm);
 
 	return (0);


### PR DESCRIPTION
Valgrind reports this loss on the server side code:
```
==86816== 4,816 (120 direct, 4,696 indirect) bytes in 1 blocks are definitely lost in loss record 5 of 5
==86816==    at 0x484A464: calloc (vg_replace_malloc.c:1328)
==86816==    by 0x406705: rx_group_t (handshake.c:130)
==86816==    by 0x406705: slave_handshake (handshake.c:497)
==86816==    by 0x404F29: slave_init (slave.c:237)
==86816==    by 0x404F29: slave_master.isra.0 (slave.c:289)
==86816==    by 0x405741: slave (slave.c:459)
==86816==    by 0x402A8F: main (main.c:380)
```
Adding the call to `group_free` solves this leak. 
for reference this is the xml file used on the client side:
```<?xml version="1.0"?>
<profile name="server_group_free.xml">
  <group nthreads="128">
        <transaction iterations="1">
            <flowop type="connect" options="remotehost=%host protocol=tcp"/>
        </transaction>
        <transaction duration="10s">
            <flowop type="write" options="size=64"/>
            <flowop type="read" options="size=1072 "/>
        </transaction>
        <transaction >
            <flowop type="disconnect" />
        </transaction>
  </group>
  <group nthreads="64">
        <transaction iterations="1">
            <flowop type="connect" options="remotehost=$host protocol=tcp"/>
        </transaction>
        <transaction duration="10s">
            <flowop type="write" options="size=64"/>
            <flowop type="read" options="size=1072 "/>
        </transaction>
        <transaction >
            <flowop type="disconnect" />
        </transaction>
  </group>

</profile>
```