### PR TITLE
Fix compilation if stdatomic.h is present

### DIFF
--- a/src/shm.h
+++ b/src/shm.h
@@ -18,6 +18,9 @@
 #ifndef _SHM_H
 #define	_SHM_H
 
+#ifdef HAVE_STDATOMIC_H
+#include <stdatomic.h>
+#endif /* HAVE_STDATOMIC_H */
 #include "logging.h"
 #include "sync.h"
 #include "workorder.h"
@@ -75,7 +78,11 @@ struct uperf_shm {
 	uperf_log_t log;
 	int global_error;
 	uint32_t sstate1[NUM_STATES];
+#ifdef HAVE_STDATOMIC_H
+	atomic_uint finished;
+#else
 	uint32_t finished;
+#endif /* HAVE_STDATOMIC_H */
 	int cleaned_up;
 
 	/* callouts */

--- a/src/sync.h
+++ b/src/sync.h
@@ -23,6 +23,9 @@
 #ifndef	_SYNC_H
 #define	_SYNC_H
 
+#ifdef HAVE_STDATOMIC_H
+#include <stdatomic.h>
+#endif /* HAVE_STDATOMIC_H */
 #include <pthread.h>
 
 #define	BARRIER_REACHED(a)		!barrier_notreached((a))
@@ -36,7 +39,11 @@ typedef	struct sync_barrier {
 	pthread_mutexattr_t count_mtx_attr;
 	pthread_mutex_t count_mutex;
 #endif /* HAVE_ATOMIC_H  && HAVE_STDATOMIC_H */
+#ifdef HAVE_STDATOMIC_H
+	atomic_uint count;
+#else
 	volatile unsigned int count;
+#endif /* HAVE_STDATOMIC_H */
 	volatile unsigned int limit;
 	int group;
 	int txn;


### PR DESCRIPTION
At least recent versions of macOS and FreeBSD provide stdatomic.h. Fix building uperf on these platfroms.