### PR TITLE
Add repeat option for flowop-internal looping

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -500,6 +500,15 @@ parse_option(char *option, flowop_t *flowop)
 			}
 		} else if (strcasecmp(key, "count") == 0) {
 			flowop->options.count = atoi(value);
+		} else if (strcasecmp(key, "repeat") == 0) {
+			int repeat = atoi(value);
+			if (repeat < 1) {
+				snprintf(err, sizeof (err),
+					"repeat (%s) should be > 0", value);
+				add_error(err);
+				return (UPERF_FAILURE);
+			}
+			flowop->options.repeat = repeat;
 		} else if (strcasecmp(key, "port") == 0) {
 			flowop->options.port = atoi(value);
 		} else if (strcasecmp(key, "protocol") == 0) {
@@ -763,6 +772,7 @@ flowop_parse_options(char *str_options, flowop_t *flowop)
 	char	*delimiters = " \t";
 
 	flowop->options.count = 1;	/* Default count */
+	flowop->options.repeat = 1;	/* Default repeat */
 	flowop->options.size = 0;	/* Default size */
 	flowop->options.duration = 0;	/* Default duration */
 	flowop->p_id = UPERF_ANY_CONNECTION;
@@ -859,6 +869,7 @@ build_worklist(struct symbol *list)
 				curr_flowop = curr_flowop->next;
 			}
 			curr_flowop->options.count = 1;
+			curr_flowop->options.repeat = 1;
 			curr_flowop->id = fid++;
 			break;
 		case TOKEN_XML_END:

--- a/src/sctp.c
+++ b/src/sctp.c
@@ -239,6 +239,9 @@ int
 protocol_sctp_write(protocol_t *p, void *buffer, int size, void *options)
 {
 	ssize_t len;
+	ssize_t total = 0;
+	int i;
+	int repeat = 1;
 	struct msghdr msg;
 	struct iovec iov;
 	struct cmsghdr *cmsg;
@@ -279,6 +282,7 @@ protocol_sctp_write(protocol_t *p, void *buffer, int size, void *options)
 
 	if (options) {
 		flowop_options_t *flowops = (flowop_options_t *) options;
+		repeat = flowops->repeat;
 
 		if (FO_SCTP_UNORDERED(flowops)) {
 			sndinfo->snd_flags |= SCTP_UNORDERED;
@@ -331,17 +335,25 @@ protocol_sctp_write(protocol_t *p, void *buffer, int size, void *options)
 
 	msg.msg_controllen = controllen;
 
-	if ((len = sendmsg(p->fd, &msg, 0)) < 0) {
-		uperf_log_msg(UPERF_LOG_WARN, errno, "Cannot sendmsg ");
+	for (i = 0; i < repeat; i++) {
+		if ((len = sendmsg(p->fd, &msg, 0)) < 0) {
+			uperf_log_msg(UPERF_LOG_WARN, errno,
+				"Cannot sendmsg ");
+			return (-1);
+		}
+		total += len;
 	}
 
-	return (len);
+	return (total);
 }
 
 int
 protocol_sctp_read(protocol_t *p, void *buffer, int size, void *options)
 {
 	ssize_t len;
+	ssize_t total = 0;
+	int i;
+	int repeat = 1;
 	struct msghdr msg;
 	struct iovec iov;
 	char cbuf[CMSG_SPACE(sizeof(struct sctp_rcvinfo))];
@@ -350,16 +362,10 @@ protocol_sctp_read(protocol_t *p, void *buffer, int size, void *options)
 	if (options) {
 		flowop_options_t *flowops = (flowop_options_t *)options;
 		timeout = flowops->poll_timeout / 1.0e+6;
-	}
-
-	if (timeout > 0) {
-		if (generic_poll(p->fd, timeout, POLLIN) <= 0) {
-			return (-1);
-		}
+		repeat = flowops->repeat;
 	}
 
 	memset(&msg, 0, sizeof(msg));
-	memset(cbuf, 0, sizeof(cbuf));
 
 	iov.iov_base = buffer;
 	iov.iov_len = size;
@@ -367,13 +373,25 @@ protocol_sctp_read(protocol_t *p, void *buffer, int size, void *options)
 	msg.msg_iov = &iov;
 	msg.msg_iovlen = 1;
 	msg.msg_control = cbuf;
-	msg.msg_controllen = sizeof(cbuf);
 
-	if ((len = recvmsg(p->fd, &msg, 0)) < 0) {
-		uperf_log_msg(UPERF_LOG_WARN, errno, "Cannot recvmsg ");
+	for (i = 0; i < repeat; i++) {
+		if (timeout > 0) {
+			if (generic_poll(p->fd, timeout, POLLIN) <= 0) {
+				return (-1);
+			}
+		}
+		memset(cbuf, 0, sizeof(cbuf));
+		msg.msg_controllen = sizeof(cbuf);
+		
+		if ((len = recvmsg(p->fd, &msg, 0)) < 0) {
+			uperf_log_msg(UPERF_LOG_WARN, errno,
+				"Cannot recvmsg ");
+			return (-1);
+		}
+		total += len;
 	}
 
-	return (len);
+	return (total);
 }
 
 static protocol_t *protocol_sctp_accept(protocol_t *p, void *options);

--- a/src/workorder.c
+++ b/src/workorder.c
@@ -300,6 +300,7 @@ group_bitswap(group_t *grp)
 			fo->duration = BSWAP_64(fo->duration);
 			fo->wndsz = BSWAP_64(fo->wndsz);
 			fo->count = BSWAP_64(fo->count);
+			fo->repeat = BSWAP_64(fo->repeat);
 			fo->poll_timeout = BSWAP_64(fo->poll_timeout);
 			fo->encaps_port = BSWAP_32(fo->encaps_port);
 			fo->sctp_rto_min = BSWAP_32(fo->sctp_rto_min);

--- a/src/workorder.h
+++ b/src/workorder.h
@@ -57,6 +57,7 @@ struct flowop_options {
 	uint64_t	duration;	/* In nanoseconds */
 	uint64_t	wndsz;		/* SCTP/TCP/UDP Window size */
 	uint64_t	count;		/* Flowop execute Count */
+	uint64_t	repeat;		/* Flowop-internal execute count */
 	uint64_t	poll_timeout;	/* In nanoseconds */
 	uint32_t	encaps_port;	/* Port used for UDP encapsulation */
 	uint32_t	bblog;	/* TCP black box logging */


### PR DESCRIPTION
Add a `repeat` option to SCTP read/write that loops sendmsg/recvmsg inside the protocol function. 

Unlike `count`, which re-enters the full protocol function (rebuilding the msghdr each time), `repeat` only repeats the syscall. This will make comparisons between sendmsg/recvmsg and sendmmsg/recvmmsg (see #69) more comparable, since those set up once and process a batch of messages in a single call.

Successfully tested on:
- Linux 7.0.10 (Fedora 44)
- FreeBSD 15.0-RELEASE
- Solaris 11.4
