### PR TITLE
Add batch_size option for sctp sendmmsg/recvmmsg usage

### DIFF
--- a/config.h.android
+++ b/config.h.android
@@ -72,6 +72,12 @@
 /* Have sendfilev */
 #undef HAVE_SENDFILEV
 
+/* Have sendmmsg */
+#undef HAVE_SENDMMSG
+
+/* Have recvmmsg */
+#undef HAVE_RECVMMSG
+
 /* Define to 1 if you have the <siginfo.h> header file. */
 #undef HAVE_SIGINFO_H
 

--- a/configure.ac
+++ b/configure.ac
@@ -228,6 +228,8 @@ AC_CHECK_FUNCS([strncpy])
 AC_CHECK_FUNCS([strncat])
 AC_CHECK_FUNCS([strlcpy])
 AC_CHECK_FUNCS([strlcat])
+AC_CHECK_FUNCS([sendmmsg])
+AC_CHECK_FUNCS([recvmmsg])
 AC_CHECK_FUNCS([gethrvtime])
 AC_CHECK_FUNCS([gethrtime],[],
 	[AC_CHECK_FUNCS([clock_gettime],[],

--- a/src/parse.c
+++ b/src/parse.c
@@ -509,6 +509,15 @@ parse_option(char *option, flowop_t *flowop)
 				return (UPERF_FAILURE);
 			}
 			flowop->options.repeat = repeat;
+		} else if (strcasecmp(key, "batch_size") == 0) {
+			int batch_size = atoi(value);
+			if (batch_size < 1) {
+				snprintf(err, sizeof (err),
+					"batch_size (%s) should be > 0", value);
+				add_error(err);
+				return (UPERF_FAILURE);
+			}
+			flowop->options.batch_size = batch_size;
 		} else if (strcasecmp(key, "port") == 0) {
 			flowop->options.port = atoi(value);
 		} else if (strcasecmp(key, "protocol") == 0) {
@@ -773,6 +782,7 @@ flowop_parse_options(char *str_options, flowop_t *flowop)
 
 	flowop->options.count = 1;	/* Default count */
 	flowop->options.repeat = 1;	/* Default repeat */
+	flowop->options.batch_size = 1; /* Default batch size */
 	flowop->options.size = 0;	/* Default size */
 	flowop->options.duration = 0;	/* Default duration */
 	flowop->p_id = UPERF_ANY_CONNECTION;
@@ -870,6 +880,7 @@ build_worklist(struct symbol *list)
 			}
 			curr_flowop->options.count = 1;
 			curr_flowop->options.repeat = 1;
+			curr_flowop->options.batch_size = 1;
 			curr_flowop->id = fid++;
 			break;
 		case TOKEN_XML_END:

--- a/src/sctp.c
+++ b/src/sctp.c
@@ -49,6 +49,7 @@
 #include "protocol.h"
 #include "generic.h"
 
+#define SCTP_MMSG_STACK_SIZE 16
 
 static void
 set_sctp_options(int fd, int family, flowop_options_t *f)
@@ -240,11 +241,16 @@ protocol_sctp_write(protocol_t *p, void *buffer, int size, void *options)
 {
 	ssize_t len;
 	ssize_t total = 0;
-	int i;
+	uint64_t i, j;
 	int repeat = 1;
+	uint64_t batch_size = 1;
+	uint64_t msgs_sent;
+	uint64_t remaining;
 	struct msghdr msg;
+	struct mmsghdr stack_mmsgs[SCTP_MMSG_STACK_SIZE];
 	struct iovec iov;
 	struct cmsghdr *cmsg;
+	struct mmsghdr *mmsgs = NULL;
 	struct sctp_sndinfo *sndinfo;
 	struct sctp_prinfo *prinfo;
 	char cmsgbuf[
@@ -283,6 +289,7 @@ protocol_sctp_write(protocol_t *p, void *buffer, int size, void *options)
 	if (options) {
 		flowop_options_t *flowops = (flowop_options_t *) options;
 		repeat = flowops->repeat;
+		batch_size = flowops->batch_size;
 
 		if (FO_SCTP_UNORDERED(flowops)) {
 			sndinfo->snd_flags |= SCTP_UNORDERED;
@@ -335,14 +342,70 @@ protocol_sctp_write(protocol_t *p, void *buffer, int size, void *options)
 
 	msg.msg_controllen = controllen;
 
-	for (i = 0; i < repeat; i++) {
-		if ((len = sendmsg(p->fd, &msg, 0)) < 0) {
-			uperf_log_msg(UPERF_LOG_WARN, errno,
-				"Cannot sendmsg ");
-			return (-1);
+#ifdef HAVE_SENDMMSG
+	if (batch_size > 1) {
+		if (batch_size <= SCTP_MMSG_STACK_SIZE) {
+			mmsgs = stack_mmsgs;
+		} else {
+			mmsgs = calloc(batch_size, sizeof(*mmsgs));
+
+			if (mmsgs == NULL) {
+				uperf_log_msg(UPERF_LOG_WARN, errno,
+				    "Cannot allocate mmsghdr array");
+				return (-1);
+			}
 		}
-		total += len;
+
+		for (j = 0; j < batch_size; j++) {
+			memset(&mmsgs[j], 0, sizeof(mmsgs[j]));
+			mmsgs[j].msg_hdr = msg;
+		}
 	}
+#endif
+
+	for (i = 0; i < repeat; i++) {
+		if (batch_size <= 1) {
+			if ((len = sendmsg(p->fd, &msg, 0)) < 0) {
+				uperf_log_msg(UPERF_LOG_WARN, errno,
+					"Cannot sendmsg ");
+				return (-1);
+			}
+			total += len;
+			continue;
+		}
+
+#ifdef HAVE_SENDMMSG
+		remaining = batch_size;
+
+		while (remaining > 0) {
+			msgs_sent = sendmmsg(p->fd,
+				&mmsgs[batch_size - remaining],
+				remaining, 0);
+
+			if (msgs_sent < 0) {
+				if (mmsgs != stack_mmsgs)
+					free(mmsgs);
+				uperf_log_msg(UPERF_LOG_WARN, errno,
+				"Cannot sendmmsg ");
+
+				return (-1);
+			}
+
+			remaining -= msgs_sent;
+		}
+
+		total += (ssize_t)size * batch_size;
+#else
+		uperf_log_msg(UPERF_LOG_WARN, errno,
+				"sendmmsg not supported ");
+
+#endif
+	}
+
+#ifdef HAVE_SENDMMSG
+	if (mmsgs != stack_mmsgs)
+		free(mmsgs);
+#endif
 
 	return (total);
 }
@@ -352,17 +415,28 @@ protocol_sctp_read(protocol_t *p, void *buffer, int size, void *options)
 {
 	ssize_t len;
 	ssize_t total = 0;
-	int i;
+	uint64_t i, j;
 	int repeat = 1;
+	uint64_t batch_size = 1;
+	int msgs_recieved;
 	struct msghdr msg;
+	struct mmsghdr stack_mmsgs[SCTP_MMSG_STACK_SIZE];
 	struct iovec iov;
+	struct iovec stack_iovs[SCTP_MMSG_STACK_SIZE];
+	struct mmsghdr *mmsgs = NULL;
+	struct iovec *iovs = NULL;
 	char cbuf[CMSG_SPACE(sizeof(struct sctp_rcvinfo))];
+	char stack_cbufs[SCTP_MMSG_STACK_SIZE]
+			[CMSG_SPACE(sizeof(struct sctp_rcvinfo))];
+	char (*cbufs)[CMSG_SPACE(sizeof(struct sctp_rcvinfo))] = NULL;
+	char *recvbuf = NULL;
 	int timeout = 0;
 
 	if (options) {
 		flowop_options_t *flowops = (flowop_options_t *)options;
 		timeout = flowops->poll_timeout / 1.0e+6;
 		repeat = flowops->repeat;
+		batch_size = flowops->batch_size;
 	}
 
 	memset(&msg, 0, sizeof(msg));
@@ -374,21 +448,129 @@ protocol_sctp_read(protocol_t *p, void *buffer, int size, void *options)
 	msg.msg_iovlen = 1;
 	msg.msg_control = cbuf;
 
-	for (i = 0; i < repeat; i++) {
-		if (timeout > 0) {
-			if (generic_poll(p->fd, timeout, POLLIN) <= 0) {
+	if (batch_size <= 1) {
+		for (i = 0; i < repeat; i++) {
+			if (timeout > 0) {
+				if (generic_poll(p->fd, timeout, POLLIN) <= 0) {
+					return (-1);
+				}
+			}
+			memset(cbuf, 0, sizeof(cbuf));
+			msg.msg_controllen = sizeof(cbuf);
+
+			if ((len = recvmsg(p->fd, &msg, 0)) < 0) {
+				uperf_log_msg(UPERF_LOG_WARN, errno,
+					"Cannot recvmsg ");
+				return (-1);
+			}
+			total += len;
+		}
+	} else {
+#ifdef HAVE_RECVMMSG
+		if (batch_size <= SCTP_MMSG_STACK_SIZE) {
+			mmsgs = stack_mmsgs;
+			iovs = stack_iovs;
+			cbufs = stack_cbufs;
+		} else {
+			mmsgs = calloc(batch_size, sizeof(*mmsgs));
+			iovs = calloc(batch_size, sizeof(*iovs));
+			cbufs = calloc(batch_size,
+				CMSG_SPACE(sizeof(struct sctp_rcvinfo)));
+
+			if (mmsgs == NULL || iovs == NULL || cbufs == NULL) {
+				free(mmsgs);
+				free(iovs);
+				free(cbufs);
+
+				uperf_log_msg(UPERF_LOG_WARN, errno,
+				    "Cannot allocate recvmmsg structures");
 				return (-1);
 			}
 		}
-		memset(cbuf, 0, sizeof(cbuf));
-		msg.msg_controllen = sizeof(cbuf);
-		
-		if ((len = recvmsg(p->fd, &msg, 0)) < 0) {
+
+		recvbuf = malloc(batch_size * size);
+		if (recvbuf == NULL) {
+			if (mmsgs != stack_mmsgs) {
+				free(mmsgs);
+				free(iovs);
+				free(cbufs);
+			}
+
 			uperf_log_msg(UPERF_LOG_WARN, errno,
-				"Cannot recvmsg ");
+			    "Cannot allocate receive buffer");
 			return (-1);
 		}
-		total += len;
+
+		for (i = 0; i < batch_size; i++) {
+			memset(&mmsgs[i], 0, sizeof(mmsgs[i]));
+
+			iovs[i].iov_base = recvbuf + ((size_t)i * size);
+			iovs[i].iov_len = size;
+
+			mmsgs[i].msg_hdr.msg_iov = &iovs[i];
+			mmsgs[i].msg_hdr.msg_iovlen = 1;
+			mmsgs[i].msg_hdr.msg_control = cbufs[i];
+			mmsgs[i].msg_hdr.msg_controllen =
+				CMSG_SPACE(sizeof(struct sctp_rcvinfo));
+		}
+
+		for (i = 0; i < repeat; i++) {
+			if (timeout > 0) {
+				if (generic_poll(p->fd, timeout, POLLIN) <= 0) {
+					free(recvbuf);
+
+					if (mmsgs != stack_mmsgs) {
+						free(mmsgs);
+						free(iovs);
+						free(cbufs);
+					}
+
+					return (-1);
+				}
+			}
+
+			for (j = 0; j < batch_size; j++) {
+				memset(cbufs[j], 0,
+					CMSG_SPACE(sizeof(struct sctp_rcvinfo)));
+
+				mmsgs[j].msg_hdr.msg_controllen =
+					CMSG_SPACE(sizeof(struct sctp_rcvinfo));
+			}
+
+			msgs_recieved = recvmmsg(p->fd, mmsgs, batch_size,
+				0, NULL);
+
+			if (msgs_recieved < 0) {
+				free(recvbuf);
+
+				if (mmsgs != stack_mmsgs) {
+					free(mmsgs);
+					free(iovs);
+					free(cbufs);
+				}
+
+				uperf_log_msg(UPERF_LOG_WARN, errno,
+					"Cannot recvmmsg ");
+
+				return (-1);
+			}
+
+			for (j = 0; j < msgs_recieved; j++) {
+				total += mmsgs[j].msg_len;
+			}
+		}
+
+		free(recvbuf);
+
+		if (mmsgs != stack_mmsgs) {
+			free(mmsgs);
+			free(iovs);
+			free(cbufs);
+		}
+#else
+		uperf_log_msg(UPERF_LOG_WARN, errno,
+				"recvmmsg not supported ");
+#endif
 	}
 
 	return (total);

--- a/src/workorder.c
+++ b/src/workorder.c
@@ -301,6 +301,7 @@ group_bitswap(group_t *grp)
 			fo->wndsz = BSWAP_64(fo->wndsz);
 			fo->count = BSWAP_64(fo->count);
 			fo->repeat = BSWAP_64(fo->repeat);
+			fo->batch_size = BSWAP_64(fo->batch_size);
 			fo->poll_timeout = BSWAP_64(fo->poll_timeout);
 			fo->encaps_port = BSWAP_32(fo->encaps_port);
 			fo->sctp_rto_min = BSWAP_32(fo->sctp_rto_min);

--- a/src/workorder.h
+++ b/src/workorder.h
@@ -58,6 +58,7 @@ struct flowop_options {
 	uint64_t	wndsz;		/* SCTP/TCP/UDP Window size */
 	uint64_t	count;		/* Flowop execute Count */
 	uint64_t	repeat;		/* Flowop-internal execute count */
+	uint64_t	batch_size;	/* SCTP/UDP sendmmsg batch size */
 	uint64_t	poll_timeout;	/* In nanoseconds */
 	uint32_t	encaps_port;	/* Port used for UDP encapsulation */
 	uint32_t	bblog;	/* TCP black box logging */


### PR DESCRIPTION
Add a `batch_size` option to SCTP read/write operations to enable the use of `recvmmsg()` and `sendmmsg()` (see #69).

When `batch_size` is greater than 1, `recvmmsg()`/`sendmmsg()` are used instead of `recvmsg()`/`sendmsg()`. For small batch sizes (`<= 16`), stack allocation is used to avoid the performance overhead of heap allocations.

Tested on:
- Linux 6.12 (Debian Trixie 13)
- FreeBSD 16.0-CURRENT
- FreeBSD 15.0-RELEASE
- Solaris 11.4