### PR TITLE
Use sendmsg() for udp write

### DIFF
--- a/src/udp.c
+++ b/src/udp.c
@@ -107,6 +107,8 @@ static int
 write_one(int fd, char *buffer, int len, struct sockaddr *to)
 {
 	socklen_t length;
+	struct msghdr msg;
+	struct iovec iov;
 
 	switch (to->sa_family) {
 	case AF_INET:
@@ -117,9 +119,20 @@ write_one(int fd, char *buffer, int len, struct sockaddr *to)
 		break;
 	default:
 		return (-1);
-		break;
 	}
-	return (sendto(fd, buffer, len, 0, to, length));
+
+	iov.iov_base = buffer;
+	iov.iov_len = len;
+
+	msg.msg_name = to;
+	msg.msg_namelen = length;
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+	msg.msg_control = NULL;
+	msg.msg_controllen = 0;
+	msg.msg_flags = 0;
+
+	return (sendmsg(fd, &msg, 0));
 }
 
 static int


### PR DESCRIPTION
This Pull Request is also part of the changes to tackle the discussion in #69.

Adjusted `write_one()` that is called by `protocol_udp_write()` to use `sendmsg()` instead of `sendto()`.

Successfully tested on
- Solaris 11.4
- FreeBSD 15.0
- Ubuntu 24.04 (kernel version 6.8.0)