### PR TITLE
Fix SEND_STATS return value handling

### DIFF
--- a/src/master.c
+++ b/src/master.c
@@ -333,10 +333,10 @@ master_poll(uperf_shm_t *shm)
 		return (1);
 	}
 	if (ENABLED_ERROR_STATS(options))  {
-		return (send_command_to_slaves(UPERF_CMD_SEND_STATS, 0));
-	} else {
-		return (0);
+		if (send_command_to_slaves(UPERF_CMD_SEND_STATS, 0) <= 0)
+			return (1);
 	}
+	return (0);
 }
 
 /* Create a control connection to a slave */


### PR DESCRIPTION
On success `send_command_to_slaves()` returns the number of bytes sent. On failure it returns 0 or less.

`master_poll()` currently returns the result of the final `send_command_to_slaves()` call directly. However `master()` treats any non-zero return value from `master_poll()` as an error and passes it to `wait_for_strands()`. When the send succeeds, the positive byte count is therefore misinterpreted as an error, causing local thread joins to be skipped.

As a result `shm_fini()` can unmap shared memory while local threads are still running, leading to sporadic segmentation faults.

Fix this by making `master_poll()` return an error value only when sending `SEND_STATS` fails and return 0 on success.