### PR TITLE
Fix mutex corruption in logging.c

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -173,7 +173,8 @@ uperf_log_flush()
 		}
 	}
 	/* reset the counters */
-	(void) memset(log, 0, sizeof (uperf_log_t));
+	(void) memset(log->msg, 0, sizeof (log->msg));
+	log->num_msg = 0;
 	(void) pthread_mutex_unlock(&log->lock);
 
 	return (UPERF_SUCCESS);


### PR DESCRIPTION
`uperf_log_flush()` resets the log with `memset(log, 0, sizeof(uperf_log_t))`, which zeroes the entire struct including the held `pthread_mutex_t` and its attributes. The reset now only clears the message buffer and counter.