### PR TITLE
Small fixes in test.sh

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -16,7 +16,7 @@ fi
 serverpid=""
 if pgrep uperf ; then
     echo "uperf server already running; please stop it and try again"
-    exit
+    exit 1
 else
     echo "Starting server - $uperf -s $csocket"
     $uperf -s $csocket &
@@ -28,7 +28,7 @@ h=$host duration=10s $uperf $csocket -m $profile >> log 2>&1
 exitstatus=$?
 
 # kill server
-if [[ serverpid != "" ]] ; then
+if [[ $serverpid != "" ]] ; then
    echo "Killing $serverpid"
    kill -9 $serverpid
 fi


### PR DESCRIPTION
Tests now fail when the server is already running.

Also fix the cleanup check to use $serverpid instead of the literal string.